### PR TITLE
Decode URL using Foundation

### DIFF
--- a/Sources/swift-httpd/http.swift
+++ b/Sources/swift-httpd/http.swift
@@ -122,7 +122,9 @@ func doFile(
   socket: UnsafeMutablePointer<FILE>?
 ) -> Int32 {
   do {
-    let filenameStr = String(cString: filename).replacingOccurrences(of: "%20", with: " ")
+    guard let filenameStr = String(cString: filename).removingPercentEncoding else {
+      return 404
+    }
     print("Handling URL Path: \(filenameStr)")
 
     let UrlPath = URL(fileURLWithPath: filenameStr)


### PR DESCRIPTION
Update the space handling to generalize for all escape sequences.  This uses the Foundation support for the URL encoding to convert the string properly.