### PR TITLE
Delete LinuxMain.swift

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import swiftdasmTests
-
-var tests = [XCTestCaseEntry]()
-tests += swiftdasmTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
This is obviously copy-paste content from a different project and does not enable any tests.  Furthermore, with newer Swift releases is entirely unnecessary.